### PR TITLE
Adds header_will_display method to PM::TableScreen

### DIFF
--- a/app/test_screens/test_table_screen.rb
+++ b/app/test_screens/test_table_screen.rb
@@ -1,6 +1,6 @@
 class TestTableScreen < ProMotion::TableScreen
 
-  attr_accessor :tap_counter, :cell_was_deleted, :got_index_path
+  attr_accessor :tap_counter, :cell_was_deleted, :got_index_path, :got_header_will_display
   title 'Test title'
   tab_bar_item title: 'Test tab title', item: 'test'
 
@@ -118,6 +118,10 @@ class TestTableScreen < ProMotion::TableScreen
         offset = CGPointMake(0, table_view.contentSize.height - table_view.frame.size.height)
         table_view.setContentOffset(offset, animated:false)
     end
+  end
+
+  def header_will_display(view, section)
+    @got_header_will_display = {view: view, section: section}
   end
 
 end

--- a/app/test_screens/test_table_screen.rb
+++ b/app/test_screens/test_table_screen.rb
@@ -1,5 +1,5 @@
 class TestTableScreen < ProMotion::TableScreen
-  attr_accessor :tap_counter, :cell_was_deleted, :got_index_path, :cell_was_moved, :got_header_will_display
+  attr_accessor :tap_counter, :cell_was_deleted, :got_index_path, :cell_was_moved, :got_will_display_header
 
   title 'Test title'
   tab_bar_item title: 'Test tab title', item: 'test'
@@ -136,8 +136,8 @@ class TestTableScreen < ProMotion::TableScreen
     end
   end
 
-  def header_will_display(view, section)
-    @got_header_will_display = {view: view, section: section}
+  def will_display_header(view, section)
+    @got_will_display_header = {view: view, section: section}
   end
 
   def table_header_view

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -226,6 +226,17 @@ module ProMotion
       end
     end
 
+    def tableView(tableView, willDisplayHeaderView:view, forSection:section)
+      action = :header_will_display
+      if respond_to?(action)
+        case self.method(action).arity
+        when 0 then self.send(action)
+        when 2 then self.send(action, view, section)
+        else self.send(action, view)
+        end
+      end
+    end
+
     protected
 
     def map_cell_editing_style(symbol)

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -296,7 +296,7 @@ module ProMotion
     end
 
     def tableView(tableView, willDisplayHeaderView:view, forSection:section)
-      action = :header_will_display
+      action = :will_display_header
       if respond_to?(action)
         case self.method(action).arity
         when 0 then self.send(action)

--- a/spec/unit/tables/table_module_spec.rb
+++ b/spec/unit/tables/table_module_spec.rb
@@ -189,4 +189,19 @@ describe "PM::Table module" do
 
   end
 
+  describe "header view modifications" do
+
+    it "should call header_will_display" do
+      header = @subject.tableView(@subject.table_view, viewForHeaderInSection: 4)
+      @subject.tableView(@subject.table_view, willDisplayHeaderView:header, forSection:1)
+
+      @subject.got_header_will_display.tap do |h|
+        h.nil?.should == false
+        h[:section].should == 1
+        h[:view].should == header
+      end
+    end
+
+  end
+
 end

--- a/spec/unit/tables/table_module_spec.rb
+++ b/spec/unit/tables/table_module_spec.rb
@@ -195,11 +195,11 @@ describe "PM::Table module" do
 
   describe "header view modifications" do
 
-    it "should call header_will_display" do
+    it "should call will_display_header" do
       header = @subject.tableView(@subject.table_view, viewForHeaderInSection: 4)
       @subject.tableView(@subject.table_view, willDisplayHeaderView:header, forSection:1)
 
-      @subject.got_header_will_display.tap do |h|
+      @subject.got_will_display_header.tap do |h|
         h.nil?.should == false
         h[:section].should == 1
         h[:view].should == header


### PR DESCRIPTION
If defined in your subclass, it will call:

`header_will_display`, `header_will_display(view)` or `header_will_display(view, section)`

This is so that you can modify the view of a header before it is displayed. This is commonly done to do things like change the background or text color of the default header view like so:

```ruby
def tableView(tableView, willDisplayHeaderView:view, forSection:section)
  view.tintColor = UIColor.redColor #  Background 
  view.textLabel.setTextColor(UIColor.blueColor) # Text Color
end
```

This new ProMotion way would be:

```ruby
def header_will_display(view) # Don't need the section index in this example
  view.tintColor = UIColor.redColor #  Background 
  view.textLabel.setTextColor(UIColor.blueColor) # Text Color
end
```