### PR TITLE
Add app method for convenient access to UIApplication.sharedApplication

### DIFF
--- a/lib/ProMotion/delegate/delegate_module.rb
+++ b/lib/ProMotion/delegate/delegate_module.rb
@@ -42,6 +42,10 @@ module ProMotion
       try :on_open_url, { url: url, source_app: source_app, annotation: annotation }
     end
 
+    def app
+      UIApplication.sharedApplication
+    end
+
     def app_delegate
       self
     end

--- a/lib/ProMotion/screen/screen_navigation.rb
+++ b/lib/ProMotion/screen/screen_navigation.rb
@@ -32,6 +32,10 @@ module ProMotion
       open screen, args.merge({ modal: true })
     end
 
+    def app
+      UIApplication.sharedApplication
+    end
+
     def app_delegate
       UIApplication.sharedApplication.delegate
     end

--- a/spec/unit/delegate_spec.rb
+++ b/spec/unit/delegate_spec.rb
@@ -80,6 +80,10 @@ describe "PM::Delegate" do
     @subject.application(UIApplication.sharedApplication, openURL: url, sourceApplication:sourceApplication, annotation: annotation)
   end
 
+  it "should have an awesome convenience method for UIApplication.sharedApplication" do
+    @subject.app.should == UIApplication.sharedApplication
+  end
+
 end
 
 # iOS 7 ONLY tests

--- a/spec/unit/screen_spec.rb
+++ b/spec/unit/screen_spec.rb
@@ -1,11 +1,9 @@
 describe "screen properties" do
 
   before do
-
     # Simulate AppDelegate setup of main screen
     @screen = HomeScreen.new modal: true, nav_bar: true
     @screen.on_load
-
   end
 
   it "should store title" do
@@ -88,6 +86,10 @@ describe "screen properties" do
   it "#should_rotate(orientation) should fire when shouldAutorotateToInterfaceOrientation(orientation) fires" do
     @screen.mock!(:should_rotate) { |orientation| orientation.should == UIInterfaceOrientationMaskPortrait }
     @screen.shouldAutorotateToInterfaceOrientation(UIInterfaceOrientationMaskPortrait)
+  end
+
+  it "should have an awesome convenience method for UIApplication.sharedApplication" do
+    @screen.app.should == UIApplication.sharedApplication
   end
 
   describe "iOS lifecycle methods" do


### PR DESCRIPTION
I'm tired of writing `UIApplication.sharedApplication`. This also makes `app.delegate` possible.