### PR TITLE
Avoid Crash in longpressable TableScreen

### DIFF
--- a/lib/ProMotion/table/extensions/longpressable.rb
+++ b/lib/ProMotion/table/extensions/longpressable.rb
@@ -17,7 +17,9 @@ module ProMotion
         return unless gesture.state == UIGestureRecognizerStateBegan
         gesture_point = gesture.locationInView(table_view)
         index_path = table_view.indexPathForRowAtPoint(gesture_point)
+        return unless index_path
         data_cell = self.promotion_table_data.cell(index_path: index_path)
+        return unless data_cell
         trigger_action(data_cell[:long_press_action], data_cell[:arguments], index_path) if data_cell[:long_press_action]
       end
     end


### PR DESCRIPTION
In my [sample project](https://github.com/satoyos/PM_Longpress),  App crashes when..
1. Long-press empty cell,
2. Long-press gray area around SearchBar.

So I tried to fix them
Sorry, I couldn't write tests to make 'Long-press' happen certainly...

![01_14_15_at_11_46_03pm](https://cloud.githubusercontent.com/assets/1769431/5740716/4b01a43e-9c49-11e4-960d-d63e6a26d873.png)
