### PR TITLE
Feature/support module

### DIFF
--- a/lib/ProMotion.rb
+++ b/lib/ProMotion.rb
@@ -16,7 +16,11 @@ Motion::Project::App.setup do |app|
     "#{core_lib}/table/cell/table_view_cell_module.rb" => [ "#{core_lib}/styling/styling.rb" ],
     "#{core_lib}/delegate/delegate.rb" => [ "#{core_lib}/delegate/delegate_parent.rb" ],
     "#{core_lib}/delegate/delegate_parent.rb" => [ "#{core_lib}/delegate/delegate_module.rb" ],
-    "#{core_lib}/delegate/delegate_module.rb" => [ "#{core_lib}/tabs/tabs.rb", "#{core_lib}/ipad/split_screen.rb" ],
+    "#{core_lib}/delegate/delegate_module.rb" => [
+      "#{core_lib}/support/support.rb",
+      "#{core_lib}/tabs/tabs.rb",
+      "#{core_lib}/ipad/split_screen.rb"
+    ],
     "#{core_lib}/screen/screen.rb" => [ "#{core_lib}/screen/screen_module.rb" ],
     "#{core_lib}/screen/screen_module.rb" => [ "#{core_lib}/screen/screen_navigation.rb" ],
     "#{core_lib}/table/data/table_data.rb" => [ "#{core_lib}/table/table.rb" ],

--- a/lib/ProMotion/delegate/delegate_module.rb
+++ b/lib/ProMotion/delegate/delegate_module.rb
@@ -1,5 +1,6 @@
 module ProMotion
   module DelegateModule
+    include ProMotion::Support
     include ProMotion::Tabs
     include ProMotion::SplitScreen if UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad
 
@@ -42,18 +43,6 @@ module ProMotion
       try :on_open_url, { url: url, source_app: source_app, annotation: annotation }
     end
 
-    def app
-      UIApplication.sharedApplication
-    end
-
-    def app_delegate
-      self
-    end
-
-    def app_window
-      window
-    end
-
     def ui_window
       (defined?(Motion) && defined?(Motion::Xray) && defined?(Motion::Xray::XrayWindow)) ? Motion::Xray::XrayWindow : UIWindow
     end
@@ -81,10 +70,6 @@ module ProMotion
 
     def apply_status_bar
       self.class.send(:apply_status_bar)
-    end
-
-    def try(method, *args)
-      send(method, *args) if respond_to?(method)
     end
 
   public

--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -1,5 +1,6 @@
 module ProMotion
   module ScreenModule
+    include ProMotion::Support
     include ProMotion::ScreenNavigation
     include ProMotion::Styling
     include ProMotion::NavBarModule
@@ -182,10 +183,6 @@ module ProMotion
       unless self.is_a?(UIViewController)
         raise StandardError.new("ERROR: Screens must extend UIViewController or a subclass of UIViewController.")
       end
-    end
-
-    def try(method, *args)
-      send(method, *args) if respond_to?(method)
     end
 
     # Class methods

--- a/lib/ProMotion/screen/screen_navigation.rb
+++ b/lib/ProMotion/screen/screen_navigation.rb
@@ -1,5 +1,6 @@
 module ProMotion
   module ScreenNavigation
+    include ProMotion::Support
 
     def open_screen(screen, args = {})
       args = { animated: true }.merge(args)
@@ -30,14 +31,6 @@ module ProMotion
 
     def open_modal(screen, args = {})
       open screen, args.merge({ modal: true })
-    end
-
-    def app
-      UIApplication.sharedApplication
-    end
-
-    def app_delegate
-      UIApplication.sharedApplication.delegate
     end
 
     def close_screen(args = {})

--- a/lib/ProMotion/support/support.rb
+++ b/lib/ProMotion/support/support.rb
@@ -1,0 +1,21 @@
+module ProMotion
+  module Support
+
+    def app
+      UIApplication.sharedApplication
+    end
+
+    def app_delegate
+      UIApplication.sharedApplication.delegate
+    end
+
+    def app_window
+      UIApplication.sharedApplication.delegate.window
+    end
+
+    def try(method, *args)
+      send(method, *args) if respond_to?(method)
+    end
+
+  end
+end

--- a/spec/unit/delegate_spec.rb
+++ b/spec/unit/delegate_spec.rb
@@ -79,11 +79,6 @@ describe "PM::Delegate" do
 
     @subject.application(UIApplication.sharedApplication, openURL: url, sourceApplication:sourceApplication, annotation: annotation)
   end
-
-  it "should have an awesome convenience method for UIApplication.sharedApplication" do
-    @subject.app.should == UIApplication.sharedApplication
-  end
-
 end
 
 # iOS 7 ONLY tests

--- a/spec/unit/screen_spec.rb
+++ b/spec/unit/screen_spec.rb
@@ -88,10 +88,6 @@ describe "screen properties" do
     @screen.shouldAutorotateToInterfaceOrientation(UIInterfaceOrientationMaskPortrait)
   end
 
-  it "should have an awesome convenience method for UIApplication.sharedApplication" do
-    @screen.app.should == UIApplication.sharedApplication
-  end
-
   describe "iOS lifecycle methods" do
 
     it "-viewDidLoad" do

--- a/spec/unit/support_spec.rb
+++ b/spec/unit/support_spec.rb
@@ -20,6 +20,11 @@ describe "PM::Support" do
     @screen.app_window.should == UIApplication.sharedApplication.delegate.window
   end
 
+  it "has a try method" do
+    @app.try(:some_method).should == nil
+    @screen.try(:some_method).should == nil
+  end
+
 end
 
 

--- a/spec/unit/support_spec.rb
+++ b/spec/unit/support_spec.rb
@@ -1,0 +1,25 @@
+describe "PM::Support" do
+
+  before do
+    @app = TestDelegate.new
+    @screen = BasicScreen.new
+  end
+
+  it "has a convenience method for UIApplication.sharedApplication" do
+    @app.app.should == UIApplication.sharedApplication
+    @screen.app.should == UIApplication.sharedApplication
+  end
+
+  it "has a convenience method for UIApplication.sharedApplication.delegate" do
+    @app.app_delegate.should == UIApplication.sharedApplication.delegate
+    @screen.app_delegate.should == UIApplication.sharedApplication.delegate
+  end
+
+  it "has a convenience method for UIApplication.sharedApplication.delegate.window" do
+    @app.app_window.should == UIApplication.sharedApplication.delegate.window
+    @screen.app_window.should == UIApplication.sharedApplication.delegate.window
+  end
+
+end
+
+

--- a/spec/unit/support_spec.rb
+++ b/spec/unit/support_spec.rb
@@ -3,26 +3,41 @@ describe "PM::Support" do
   before do
     @app = TestDelegate.new
     @screen = BasicScreen.new
+    @tab_screen = TabScreen.new
+    @table_screen = TestTableScreen.new
+    @web_screen = TestWebScreen.new
   end
 
   it "has a convenience method for UIApplication.sharedApplication" do
     @app.app.should == UIApplication.sharedApplication
     @screen.app.should == UIApplication.sharedApplication
+    @tab_screen.app.should == UIApplication.sharedApplication
+    @table_screen.app.should == UIApplication.sharedApplication
+    @web_screen.app.should == UIApplication.sharedApplication
   end
 
   it "has a convenience method for UIApplication.sharedApplication.delegate" do
     @app.app_delegate.should == UIApplication.sharedApplication.delegate
     @screen.app_delegate.should == UIApplication.sharedApplication.delegate
+    @tab_screen.app_delegate.should == UIApplication.sharedApplication.delegate
+    @table_screen.app_delegate.should == UIApplication.sharedApplication.delegate
+    @web_screen.app_delegate.should == UIApplication.sharedApplication.delegate
   end
 
   it "has a convenience method for UIApplication.sharedApplication.delegate.window" do
     @app.app_window.should == UIApplication.sharedApplication.delegate.window
     @screen.app_window.should == UIApplication.sharedApplication.delegate.window
+    @tab_screen.app_window.should == UIApplication.sharedApplication.delegate.window
+    @table_screen.app_window.should == UIApplication.sharedApplication.delegate.window
+    @web_screen.app_window.should == UIApplication.sharedApplication.delegate.window
   end
 
   it "has a try method" do
     @app.try(:some_method).should == nil
     @screen.try(:some_method).should == nil
+    @tab_screen.try(:some_method).should == nil
+    @table_screen.try(:some_method).should == nil
+    @web_screen.try(:some_method).should == nil
   end
 
 end


### PR DESCRIPTION
As per discussion in #594. I've moved `app`, `app_delegate`, `app_window`, and `try` into a `PM::Support` module that is included in all screen objects and makes it easy to include in non-PM classes.