### PR TITLE
Don't use on_init within WebScreen

### DIFF
--- a/app/test_screens/test_web_screen.rb
+++ b/app/test_screens/test_web_screen.rb
@@ -5,6 +5,14 @@ class TestWebScreen < PM::WebScreen
   # accesor for wait_change method which is testing helper
   attr_accessor :is_load_started, :is_load_finished, :is_load_failed, :is_load_failed_error
 
+  def on_init
+    @on_init_available = true
+  end
+
+  def on_init_available?
+    @on_init_available
+  end
+
   def content
     nil
   end

--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -8,26 +8,24 @@ module ProMotion
       self.external_links ||= false
       self.scale_to_fit ||= false
       self.detector_types ||= :none
+
+      web_view_setup
+      set_initial_content
     end
 
     def on_init
-      if self.detector_types.is_a? Array
-        detectors = UIDataDetectorTypeNone
-        self.detector_types.each { |dt| detectors |= map_detector_symbol(dt) }
-        self.detector_types = detectors
-      else
-        self.detector_types = map_detector_symbol(self.detector_types)
-      end
+      # TODO: Remove in 3.0
+    end
 
+    def web_view_setup
       self.webview ||= add UIWebView.new, {
         frame: CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height),
         delegate: self,
-        data_detector_types: self.detector_types
+        data_detector_types: data_detector_types
       }
       self.webview.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight
       self.webview.scalesPageToFit = self.scale_to_fit
       self.webview.scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
-      set_initial_content
     end
 
     def web
@@ -35,10 +33,8 @@ module ProMotion
     end
 
     def set_initial_content
-      return unless self.respond_to?(:content)
-      current_content = content
-      return unless current_content
-      current_content.is_a?(NSURL) ? open_url(current_content) : set_content(current_content)
+      return unless self.respond_to?(:content) && self.content
+      self.content.is_a?(NSURL) ? open_url(self.content) : set_content(self.content)
     end
 
     def set_content(content)
@@ -146,6 +142,12 @@ module ProMotion
     end
 
     protected
+
+    def data_detector_types
+      Array(self.detector_types).reduce(UIDataDetectorTypeNone) do |detectors, dt|
+        detectors | map_detector_symbol(dt)
+      end
+    end
 
     def map_detector_symbol(symbol)
       {

--- a/spec/unit/web_spec.rb
+++ b/spec/unit/web_spec.rb
@@ -4,6 +4,11 @@ describe "web screen properties" do
   before  { disable_network_access! }
   after   { enable_network_access! }
 
+  it "should leave on_init available as a hook" do
+    webscreen = TestWebScreen.new()
+    webscreen.on_init_available?.should == true
+  end
+
   describe "when open web page with http request" do
     before do
       class TestWebScreenWithHTTPRequest < TestWebScreen


### PR DESCRIPTION
Fixes #598. Also cleans up a bit of the setup logic.