### PR TITLE
Fixes issue with auto-detected links not opening.

### DIFF
--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -119,13 +119,15 @@ module ProMotion
 
     # UIWebViewDelegate Methods - Camelcase
     def webView(inWeb, shouldStartLoadWithRequest:inRequest, navigationType:inType)
-      if self.external_links == true && inType == UIWebViewNavigationTypeLinkClicked
-        if defined?(OpenInChromeController)
-          open_in_chrome inRequest
-        else
-          open_in_safari inRequest
+      if %w(http https).include?(inRequest.URL.scheme)
+        if self.external_links == true && inType == UIWebViewNavigationTypeLinkClicked
+          if defined?(OpenInChromeController)
+            open_in_chrome inRequest
+          else
+            open_in_safari inRequest
+          end
+          return false # don't allow the web view to load the link.
         end
-        return false #don't allow the web view to load the link.
       end
 
       load_request_enable = true #return true on default for local file loading.

--- a/lib/ProMotion/web/web_screen_module.rb
+++ b/lib/ProMotion/web/web_screen_module.rb
@@ -104,34 +104,34 @@ module ProMotion
     def stop; web.stopLoading; end
     alias :reload :refresh
 
-    def open_in_chrome(inRequest)
+    def open_in_chrome(in_request)
       # Add pod 'OpenInChrome' to your Rakefile if you want links to open in Google Chrome for users.
       # This will fall back to Safari if the user doesn't have Chrome installed.
       chrome_controller = OpenInChromeController.sharedInstance
-      return open_in_safari(inRequest) unless chrome_controller.isChromeInstalled
-      chrome_controller.openInChrome(inRequest.URL)
+      return open_in_safari(in_request) unless chrome_controller.isChromeInstalled
+      chrome_controller.openInChrome(in_request.URL)
     end
 
-    def open_in_safari(inRequest)
+    def open_in_safari(in_request)
       # Open UIWebView delegate links in Safari.
-      UIApplication.sharedApplication.openURL(inRequest.URL)
+      UIApplication.sharedApplication.openURL(in_request.URL)
     end
 
     # UIWebViewDelegate Methods - Camelcase
-    def webView(inWeb, shouldStartLoadWithRequest:inRequest, navigationType:inType)
-      if %w(http https).include?(inRequest.URL.scheme)
-        if self.external_links == true && inType == UIWebViewNavigationTypeLinkClicked
+    def webView(in_web, shouldStartLoadWithRequest:in_request, navigationType:in_type)
+      if %w(http https).include?(in_request.URL.scheme)
+        if self.external_links == true && in_type == UIWebViewNavigationTypeLinkClicked
           if defined?(OpenInChromeController)
-            open_in_chrome inRequest
+            open_in_chrome in_request
           else
-            open_in_safari inRequest
+            open_in_safari in_request
           end
           return false # don't allow the web view to load the link.
         end
       end
 
       load_request_enable = true #return true on default for local file loading.
-      load_request_enable = !!on_request(inRequest, inType) if self.respond_to?(:on_request)
+      load_request_enable = !!on_request(in_request, in_type) if self.respond_to?(:on_request)
       load_request_enable
     end
 


### PR DESCRIPTION
Now for external links it specifically looks for `http` or `https` in the url scheme, thus allowing the system to handle `map` links, `tel:`, `sms:`, `itms` and `mailto:` (and whatever else that's not a simple web link to be opened in safari or google chrome.