### PR TITLE
Add image inset support for tab bar item

### DIFF
--- a/app/test_screens/tab_screen.rb
+++ b/app/test_screens/tab_screen.rb
@@ -1,4 +1,4 @@
 class TabScreen < PM::Screen
   title "Tab"
-  tab_bar_item title: "Tab Item", item: "list"
+  tab_bar_item title: "Tab Item", item: "list", image_insets: [5,5,5,5]
 end

--- a/lib/ProMotion/tabs/tabs.rb
+++ b/lib/ProMotion/tabs/tabs.rb
@@ -66,6 +66,7 @@ module ProMotion
       tab_bar_item = create_tab_bar_item_custom(title, tab[:item], current_tag) if tab[:item]
 
       tab_bar_item.badgeValue = tab[:badge_number].to_s unless tab[:badge_number].nil? || tab[:badge_number] <= 0
+      tab_bar_item.imageInsets = tab[:image_insets] if tab[:image_insets]
 
       tab_bar_item
     end

--- a/spec/unit/tab_spec.rb
+++ b/spec/unit/tab_spec.rb
@@ -25,6 +25,10 @@ describe "tab bar functionality" do
     @tab_bar.tabBar.items.first.title.should == "Tab Item"
   end
 
+  it "should allow setting image insets" do
+    @tab_bar.tabBar.items.first.imageInsets.should == UIEdgeInsetsMake(5,5,5,5)
+  end
+
   it "should have set the others to their respective titles" do
     @tab_bar.tabBar.items[1].title.should == "Basic"
     @tab_bar.tabBar.items[2].title.should == "Home"


### PR DESCRIPTION
@jamonholmgren I was considering doing the `:properties` hash thing but this is one of the last tab bar item properties left for us to implement. This way feels more consistent with what we already have.