### PR TITLE
The logger shuldn't complain when setting a modal transition style on a screen

### DIFF
--- a/lib/ProMotion/styling/styling.rb
+++ b/lib/ProMotion/styling/styling.rb
@@ -2,7 +2,10 @@ module ProMotion
   module Styling
     def set_attributes(element, args = {})
       args = get_attributes_from_symbol(args)
-      args.each { |k, v| set_attribute(element, k, v) }
+      ignore_keys = [:transition_style, :presentation_style]
+      args.each do |k, v|
+        set_attribute(element, k, v) unless ignore_keys.include?(k)
+      end
       element.send(:on_styled) if element.respond_to?(:on_styled)
       element
     end


### PR DESCRIPTION
Previously when opening a screen like this:

```ruby
    open_modal MyScreen.new(
      nav_bar: true,
      transition_style: UIModalTransitionStyleFlipHorizontal,
      presentation_style: UIModalPresentationFormSheet,
      ), animated:true
```

The logger would complain with:

```
ProMotion::Logger: [DEBUG] set_attribute: #<MyScreen:0x1199e96d0> does not respond to transitionStyle=.
ProMotion::Logger: [DEBUG] set_attribute: #<MyScreen:0x1199e96d0> does not respond to presentationStyle=.
```

This fixes the error by not trying to set those attributes on the screen.