### PR TITLE
As per apple docs, setFinishedSelectedImage:withFinishedUnselectedImage: is deprecated as of 7.0

### DIFF
--- a/lib/ProMotion/tabs/tabs.rb
+++ b/lib/ProMotion/tabs/tabs.rb
@@ -41,7 +41,8 @@ module ProMotion
       item = UITabBarItem.alloc.initWithTitle(title, image: item_image, tag: tag)
 
       if item_selected || item_unselected
-        item.setFinishedSelectedImage(item_selected, withFinishedUnselectedImage: item_unselected)
+        item.image = item_unselected
+        item.selectedImage = item_selected
       end
 
       item


### PR DESCRIPTION
This updates the code to follow apple's recommended way of setting selected and unselected images for `UITabBarItem`s