### PR TITLE
Handle additional status_bar scenarios

### DIFF
--- a/docs/Reference/API Reference - ProMotion Screen.md
+++ b/docs/Reference/API Reference - ProMotion Screen.md
@@ -466,7 +466,7 @@ end
 
 #### status_bar(style=nil, args={animation: UIStatusBarAnimationSlide})
 
-Set the properties of the applications' status bar. Options for style are: `:none`, `:light` and `:default`. The animation argument should be a `UIStatusBarAnimation` (or `:none` / `:fade` / `:slide`) and is used to hide or show the status bar when appropriate and defaults to `:slide`.
+Set the properties of the application's status bar. Options for style are: `:none`, `:light`, `:dark`, and `:default`. If a screen doesn't call `status_bar` and a `UIStatusBarStyle` is set on the application bundle, then that style will be used. Otherwise, `UIStatusBarStyleDefault` will be used. The animation argument should be a `UIStatusBarAnimation` (or `:none` / `:fade` / `:slide`) and is used to hide or show the status bar when appropriate and defaults to `:slide`.
 
 ```ruby
 class MyScreen < PM::Screen

--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -42,9 +42,13 @@ module ProMotion
       when :light
         status_bar_hidden false
         status_bar_style UIStatusBarStyleLightContent
-      else
+      when :dark
         status_bar_hidden false
         status_bar_style UIStatusBarStyleDefault
+      else
+        status_bar_hidden false
+        global_style = NSBundle.mainBundle.objectForInfoDictionaryKey("UIStatusBarStyle")
+        status_bar_style global_style ? Object.const_get(global_style) : UIStatusBarStyleDefault
       end
     end
 

--- a/spec/unit/screen_spec.rb
+++ b/spec/unit/screen_spec.rb
@@ -43,6 +43,24 @@ describe "screen properties" do
     UIApplication.sharedApplication.statusBarStyle.should == UIStatusBarStyleLightContent
   end
 
+  it "should set the UIStatusBar style to :dark" do
+    UIApplication.sharedApplication.statusBarStyle = UIStatusBarStyleLightContent
+    @screen.class.status_bar :dark
+    @screen.view_will_appear(false)
+    UIApplication.sharedApplication.isStatusBarHidden.should == false
+    UIApplication.sharedApplication.statusBarStyle.should == UIStatusBarStyleDefault
+  end
+
+  it "should default to a global UIStatusBar style" do
+    NSBundle.mainBundle.mock!(:objectForInfoDictionaryKey) do |key|
+      "UIStatusBarStyleLightContent"
+    end
+    @screen.class.status_bar :default
+    @screen.view_will_appear(false)
+    UIApplication.sharedApplication.isStatusBarHidden.should == false
+    UIApplication.sharedApplication.statusBarStyle.should == UIStatusBarStyleLightContent
+  end
+
   it "should set the tab bar item with a system item" do
     @screen.set_tab_bar_item system_item: :contacts
     comparison = UITabBarItem.alloc.initWithTabBarSystemItem(UITabBarSystemItemContacts, tag: 0)


### PR DESCRIPTION
Fixes #668. 

- When there is no `status_bar` call in a screen (which by default sets `status_bar_type` to `:default`), the old approach was to just force `UIStatusBarStyleDefault`, ignoring whatever global setting might be set in the app bundle. The new approach is to use what's specified in the `UIStatusBarStyle` entry in the main bundle (e.g. `UIStatusBarStyleLightContent`), and if that's not set, then use `UIStatusBarStyleDefault`.
- Since "dark" is not longer assumed by default, I added a `:dark` setting to use `UIStatusBarStyleDefault` on a screen (useful when the global setting is to use `:light`).

I think the only possible downside is that `:default` doesn't always mean `UIStatusBarStyleDefault`, but instead "whatever the default/global setting is for this app". If you want `UIStatusBarStyleDefault` (which I feel is maybe a poorly named constant by Apple), you'd use `:dark`. So this may add confusion.

If we want to stay consistent with Apple's naming, I'll gladly change this to make `:default` replace `:dark`, and then make the fallback something different like `:unspecified` or `:global` or something.
