### PR TITLE
Fix for #653, editing_style: :none not working properly with VoiceOver

### DIFF
--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -20,6 +20,7 @@ module ProMotion
       set_up_refreshable
       set_up_longpressable
       set_up_row_height
+      set_up_accessibility
     end
 
     def check_table_data
@@ -88,6 +89,19 @@ module ProMotion
         self.view.estimatedRowHeight = params[:estimated]
       end
     end
+
+    def editable?
+	    self.promotion_table_data.sections.each do |section|
+		    section[:cells].each do |cell|
+			    return true if [:insert,:delete].include?(cell[:editing_style])
+		    end
+	    end
+	    false
+    end
+
+    def set_up_accessibility
+				    self.extend(Editable) if editable?
+end
 
     def searching?
       self.promotion_table_data.filtered
@@ -235,10 +249,12 @@ module ProMotion
       map_cell_editing_style(data_cell[:editing_style])
     end
 
+    module Editable
     def tableView(_, commitEditingStyle: editing_style, forRowAtIndexPath: index_path)
       if editing_style == UITableViewCellEditingStyleDelete
         delete_row(index_path)
       end
+    end
     end
 
     def tableView(_, canMoveRowAtIndexPath:index_path)

--- a/spec/unit/tables/table_screen_spec.rb
+++ b/spec/unit/tables/table_screen_spec.rb
@@ -74,8 +74,10 @@ class NoneditableTableScreen < PM::TableScreen
 end
 noneditable=NoneditableTableScreen.new
 noneditable.on_load
+noneditable.editable?.should==false
 index_path=NSIndexPath.indexPathForRow(0, inSection: 0)
 lambda {noneditable.tableView(noneditable, commitEditingStyle: UITableViewCellEditingStyleDelete, forRowAtIndexPath: index_path)}.should.raise NoMethodError
+@screen.editable?.must==true
 @screen.should.respond_to(:"tableView:commitEditingStyle:forRowAtIndexPath")
     end
 

--- a/spec/unit/tables/table_screen_spec.rb
+++ b/spec/unit/tables/table_screen_spec.rb
@@ -63,6 +63,22 @@ describe "table screens" do
       screen.view.estimatedRowHeight.should == 77
     end
 
+    it "sets up proper accessibility methods" do
+class NoneditableTableScreen < PM::TableScreen
+	def on_load
+	end
+	def table_data
+		[{title: test,
+			cells: [{title: "Non-editable test"}]}]
+	end
+end
+noneditable=NoneditableTableScreen.new
+noneditable.on_load
+index_path=NSIndexPath.indexPathForRow(0, inSection: 0)
+lambda {noneditable.tableView(noneditable, commitEditingStyle: UITableViewCellEditingStyleDelete, forRowAtIndexPath: index_path)}.should.raise NoMethodError
+@screen.should.respond_to(:"tableView:commitEditingStyle:forRowAtIndexPath")
+    end
+
   end
 
   describe "search functionality" do

--- a/spec/unit/tables/table_screen_spec.rb
+++ b/spec/unit/tables/table_screen_spec.rb
@@ -68,7 +68,7 @@ class NoneditableTableScreen < PM::TableScreen
 	def on_load
 	end
 	def table_data
-		[{title: test,
+		[{title: "test",
 			cells: [{title: "Non-editable test"}]}]
 	end
 end
@@ -77,7 +77,7 @@ noneditable.on_load
 noneditable.editable?.should==false
 index_path=NSIndexPath.indexPathForRow(0, inSection: 0)
 lambda {noneditable.tableView(noneditable, commitEditingStyle: UITableViewCellEditingStyleDelete, forRowAtIndexPath: index_path)}.should.raise NoMethodError
-@screen.editable?.must==true
+@screen.editable?.should==true
 @screen.should.respond_to(:"tableView:commitEditingStyle:forRowAtIndexPath")
     end
 


### PR DESCRIPTION
This fixes #653. It implements the suggested solution. Now tables with non-editable cells read properly with VoiceOver. Developers who use PM::TableScreen might like to note this improvement in their app's changelog.