### PR TITLE
Added on_cell_created and on_cell_reused

### DIFF
--- a/docs/Reference/API Reference - ProMotion TableScreen.md
+++ b/docs/Reference/API Reference - ProMotion TableScreen.md
@@ -207,6 +207,34 @@ def table_data_index
 end
 ```
 
+#### on_cell_created(cell, data)
+
+Called when a cell is created (not dequeued).  `data` is the cell hash you provided in the `table_data` method.
+
+It's recommended that you call `super` if you override this method.
+
+```ruby
+def on_cell_created(cell, data)
+  super
+  cell.my_cool_method(data[:properties][:my_property])
+  cell.contentView.backgroundColor = UIColor.purpleColor
+end
+```
+
+#### on_cell_reused(cell, data)
+
+Called when a cell is dequeued and re-used. `data` is the cell hash you provided in the `table_data` method.
+
+It's recommended that you call `super` if you override this method.
+
+```ruby
+def on_cell_reused(cell, data)
+  super
+  cell.my_cool_method(data[:properties][:my_property])
+  cell.contentView.backgroundColor = UIColor.purpleColor
+end
+```
+
 #### on_cell_deleted(cell)
 
 If you specify `editing_style: :delete` in your cell, you can swipe to reveal a delete button on that cell. When you tap the button, the cell will be removed in an animated fashion and the cell will be removed from its respective `table_data` section.

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -169,12 +169,20 @@ module ProMotion
         new_cell.extend(PM::TableViewCellModule) unless new_cell.is_a?(PM::TableViewCellModule)
         new_cell.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleLeftMargin|UIViewAutoresizingFlexibleRightMargin
         new_cell.clipsToBounds = true # fix for changed default in 7.1
-        new_cell.send(:on_load) if new_cell.respond_to?(:on_load)
+        on_cell_created new_cell, data_cell
         new_cell
       end
       table_cell.setup(data_cell, self) if table_cell.respond_to?(:setup)
-      table_cell.send(:on_reuse) if !new_cell && table_cell.respond_to?(:on_reuse)
+      on_cell_reused(table_cell, data_cell) if !new_cell
       table_cell
+    end
+
+    def on_cell_created(new_cell, data_cell)
+      new_cell.on_load if new_cell.respond_to?(:on_load)
+    end
+
+    def on_cell_reused(cell, data)
+      cell.send(:on_reuse) if cell.respond_to?(:on_reuse)
     end
 
     def update_table_data(args = {})


### PR DESCRIPTION
For RedPotion, we need to access the cell right after it's created. This adds two hooks:

#### on_cell_created(cell, data)

Called when a cell is created (not dequeued).  `data` is the cell hash you provided in the `table_data` method.

It's recommended that you call `super` if you override this method.

```ruby
def on_cell_created(cell, data)
  super
  cell.my_cool_method(data[:properties][:my_property])
  cell.contentView.backgroundColor = UIColor.purpleColor
end
```

#### on_cell_reused(cell, data)

Called when a cell is dequeued and re-used. `data` is the cell hash you provided in the `table_data` method.

It's recommended that you call `super` if you override this method.

```ruby
def on_cell_reused(cell, data)
  super
  cell.my_cool_method(data[:properties][:my_property])
  cell.contentView.backgroundColor = UIColor.purpleColor
end
```

