### PR TITLE
Hotfix for issue with canEditRowAtIndexPath

### DIFF
--- a/lib/ProMotion/table/data/table_data.rb
+++ b/lib/ProMotion/table/data/table_data.rb
@@ -27,7 +27,7 @@ module ProMotion
       params = index_path_to_section_index(params)
       table_section = params[:unfiltered] ? self.data[params[:section]] : self.section(params[:section])
       c = table_section[:cells].at(params[:index].to_i)
-      set_data_cell_defaults c
+      set_data_cell_defaults(c)
     end
 
     def delete_cell(params={})

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -214,7 +214,7 @@ module ProMotion
     end
 
     def tableView(_, canEditRowAtIndexPath:index_path)
-      data_cell = self.promotion_table_data.cell(index_path: index_path, unfiltered: true)
+      data_cell = cell_at(index_path: index_path, unfiltered: true)
       [:insert,:delete].include?(data_cell[:editing_style])
     end
 


### PR DESCRIPTION
We weren't using the new `cell_at` method here. Self-merging to master.