### PR TITLE
We need to require motion_print in the main lib file

### DIFF
--- a/lib/ProMotion.rb
+++ b/lib/ProMotion.rb
@@ -2,6 +2,8 @@ unless defined?(Motion::Project::Config)
   raise "The ProMotion gem must be required within a RubyMotion project Rakefile."
 end
 
+require 'motion_print'
+
 Motion::Project::App.setup do |app|
   core_lib = File.join(File.dirname(__FILE__), 'ProMotion')
   insert_point = app.files.find_index { |file| file =~ /^(?:\.\/)?app\// } || 0


### PR DESCRIPTION
Fixes #696.

@seantan can you try out this branch and report back? If it works i'll release 2.4.2.

```ruby
gem 'ProMotion', github: 'clearsightstudio/ProMotion', branch: 'motion_print_require'
```

thanks!