### PR TITLE
Update table_builder.rb

### DIFF
--- a/lib/ProMotion/table/table_builder.rb
+++ b/lib/ProMotion/table/table_builder.rb
@@ -2,10 +2,12 @@ module ProMotion
   module TableBuilder
     def trigger_action(action, arguments, index_path)
       return mp("Action not implemented: #{action.to_s}", force_color: :green) unless self.respond_to?(action)
-      case self.method(action).arity
+      case arity = self.method(action).arity
       when 0 then self.send(action) # Just call the method
-      when -2 then self.send(action, arguments, index_path) # Send arguments and index path
-      else self.send(action, arguments) # Send arguments
+      when 2 then self.send(action, arguments, index_path) # Send arguments and index path
+      else 
+        mp("Action should not have optional parameters: #{action.to_s}", force_color: :yellow) if arity < 0
+        self.send(action, arguments) # Send arguments
       end
     end
 

--- a/lib/ProMotion/table/table_builder.rb
+++ b/lib/ProMotion/table/table_builder.rb
@@ -4,7 +4,7 @@ module ProMotion
       return mp("Action not implemented: #{action.to_s}", force_color: :green) unless self.respond_to?(action)
       case self.method(action).arity
       when 0 then self.send(action) # Just call the method
-      when 2 then self.send(action, arguments, index_path) # Send arguments and index path
+      when -2 then self.send(action, arguments, index_path) # Send arguments and index path
       else self.send(action, arguments) # Send arguments
       end
     end


### PR DESCRIPTION
Fixed problem of `self.method(action).arity` case with `-2` value instead of `2`.
`self.method(action).arity` returns less then zero value if the action has at least one parameter.

Checked on:
```
# RubyMotion version
motion --version
3.12
# Ruby version
ruby -v
ruby 2.0.0p481
```