### PR TITLE
SplitScreen support for iPhone after iOS 8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ end
 |[![ProMotion TableScreen](https://f.cloud.github.com/assets/1479215/1534137/ed71e864-4c90-11e3-98aa-ed96049f5407.png)](http://promotion.readthedocs.org/en/master/Reference/API%20Reference%20-%20ProMotion%20TableScreen/)|[![Grouped Table Screen](https://f.cloud.github.com/assets/1479215/1589973/61a48610-5281-11e3-85ac-abee99bf73ad.png)](https://gist.github.com/jamonholmgren/382a6cf9963c5f0b2248)|[![Searchable](https://f.cloud.github.com/assets/1479215/1534299/20cc05c6-4c93-11e3-92ca-9ee39c044457.png)](http://promotion.readthedocs.org/en/master/Reference/API%20Reference%20-%20ProMotion%20TableScreen/#searchableplaceholder-placeholder-text)|[![Refreshable](https://f.cloud.github.com/assets/1479215/1534317/5a14ef28-4c93-11e3-8e9e-f8c08d8464f8.png)](http://promotion.readthedocs.org/en/master/Reference/API%20Reference%20-%20ProMotion%20TableScreen/#refreshableoptions)|
 
 
-|iPad SplitScreens|Map Screens|Web Screens|
+|SplitScreens|Map Screens|Web Screens|
 |---|---|---|
 |[![ProMotion SplitScreens](https://f.cloud.github.com/assets/1479215/1534507/0edb8dd4-4c96-11e3-9896-d4583d0ed161.png)](http://promotion.readthedocs.org/en/master/Reference/API%20Reference%20-%20ProMotion%20SplitScreen/)|[![MapScreen](https://f.cloud.github.com/assets/1479215/1534628/f7dbf7e8-4c97-11e3-8817-4c2a58824771.png)](http://promotion.readthedocs.org/en/master/Reference/API%20Reference%20-%20ProMotion%20MapScreen/)|[![ProMotion WebScreen](https://f.cloud.github.com/assets/1479215/1534631/ffe1b36a-4c97-11e3-8c8f-c7b14e26182d.png)](http://promotion.readthedocs.org/en/master/Reference/API%20Reference%20-%20ProMotion%20WebScreen/)|
 

--- a/docs/Reference/API Reference - ProMotion Delegate.md
+++ b/docs/Reference/API Reference - ProMotion Delegate.md
@@ -108,7 +108,7 @@ end
 
 #### open_split_screen(master, detail)
 
-**iPad apps only**
+**Before iOS 8, iPad apps only**
 
 Opens a UISplitScreenViewController with the specified screens as the root view controller of the current app
 

--- a/docs/Reference/API Reference - ProMotion SplitScreen.md
+++ b/docs/Reference/API Reference - ProMotion SplitScreen.md
@@ -19,7 +19,7 @@ end
 
 #### open_split_screen(master, detail, args = {})
 
-*iPad apps only*
+*Before iOS 8, iPad apps only*
 Opens a UISplitScreenViewController with the specified screens. Usually opened in the AppDelegate as the root view controller.
 
 ```ruby

--- a/lib/ProMotion/delegate/delegate_module.rb
+++ b/lib/ProMotion/delegate/delegate_module.rb
@@ -2,7 +2,7 @@ module ProMotion
   module DelegateModule
     include ProMotion::Support
     include ProMotion::Tabs
-    include ProMotion::SplitScreen if UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad
+    include ProMotion::SplitScreen if UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad || (UIDevice.currentDevice.systemVersion.to_i >= 8 )
 
     attr_accessor :window, :home_screen
 

--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -5,7 +5,7 @@ module ProMotion
     include ProMotion::Styling
     include ProMotion::NavBarModule
     include ProMotion::Tabs
-    include ProMotion::SplitScreen if UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad
+    include ProMotion::SplitScreen if UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad || (UIDevice.currentDevice.systemVersion.to_i >= 8 )
 
     attr_accessor :parent_screen, :first_screen, :modal, :split_screen
 


### PR DESCRIPTION
After iOS 8 `UISplitViewController` is available on iPhone as well as iPad.

Tests run on iPad I wasn't able to run tests on the iPhone 6 or 6 plus simulator before or after this change.

I did test in situ in one of my applications, had no issues.

I'm open to suggestions for automated tests here.