### PR TITLE
Change behavior of screen title so that it will be nil by default

### DIFF
--- a/app/test_screens/untitled_screen.rb
+++ b/app/test_screens/untitled_screen.rb
@@ -1,0 +1,2 @@
+class UntitledScreen < PM::Screen
+end

--- a/lib/ProMotion/screen/screen_module.rb
+++ b/lib/ProMotion/screen/screen_module.rb
@@ -218,7 +218,7 @@ module ProMotion
         end
         @title = t if t
         @title_type = :text if t
-        @title ||= self.to_s
+        @title
       end
 
       def title_type

--- a/spec/unit/screen_spec.rb
+++ b/spec/unit/screen_spec.rb
@@ -6,6 +6,16 @@ describe "screen properties" do
     @screen.on_load
   end
 
+  it "does not have a default title" do
+    screen = UntitledScreen.new
+    screen.title.should == nil
+  end
+
+  it "does not display a default title in the nav bar" do
+    screen = UntitledScreen.new
+    screen.navigationItem.title.should == nil
+  end
+
   it "should store title" do
     HomeScreen.title.should == "Home"
   end


### PR DESCRIPTION
This PR changes the behavior of screen title so that it will be nil by default.

Fixes #703 