### PR TITLE
Allow proc as :action in cells

### DIFF
--- a/lib/ProMotion/table/table_builder.rb
+++ b/lib/ProMotion/table/table_builder.rb
@@ -1,24 +1,13 @@
 module ProMotion
   module TableBuilder
     def trigger_action(action, arguments, index_path)
-      if action.is_a?(Proc)
-        case arity = action.arity
-        when 0 then action.call # Just call the proc
-        when 1 then action.call(arguments) # Send arguments
-        when 2 then action.call(arguments, index_path) # Send arguments and index path
-        else
-          mp("#{arity} parameters are not supported", force_color: :yellow)
-        end
+      action = (action.is_a?(Proc) ? action : method(action))
+      case arity = action.arity
+      when 0 then action.call # Just call the proc or the method
+      when 2 then action.call(arguments, index_path) # Send arguments and index path
       else
-        return mp("Action not implemented: #{action.to_s}", force_color: :green) unless self.respond_to?(action)
-
-        case arity = self.method(action).arity
-        when 0 then self.send(action) # Just call the method
-        when 2 then self.send(action, arguments, index_path) # Send arguments and index path
-        else
-          mp("Action should not have optional parameters: #{action.to_s}", force_color: :yellow) if arity < 0
-          self.send(action, arguments) # Send arguments
-        end
+        mp("Action should not have optional parameters: #{action.to_s}", force_color: :yellow) if arity < 0
+        action.call(arguments) # Send arguments
       end
     end
 

--- a/lib/ProMotion/table/table_builder.rb
+++ b/lib/ProMotion/table/table_builder.rb
@@ -1,13 +1,24 @@
 module ProMotion
   module TableBuilder
     def trigger_action(action, arguments, index_path)
-      return mp("Action not implemented: #{action.to_s}", force_color: :green) unless self.respond_to?(action)
-      case arity = self.method(action).arity
-      when 0 then self.send(action) # Just call the method
-      when 2 then self.send(action, arguments, index_path) # Send arguments and index path
-      else 
-        mp("Action should not have optional parameters: #{action.to_s}", force_color: :yellow) if arity < 0
-        self.send(action, arguments) # Send arguments
+      if action.is_a?(Proc)
+        case arity = action.arity
+        when 0 then action.call # Just call the proc
+        when 1 then action.call(arguments) # Send arguments
+        when 2 then action.call(arguments, index_path) # Send arguments and index path
+        else
+          mp("#{arity} parameters are not supported", force_color: :yellow)
+        end
+      else
+        return mp("Action not implemented: #{action.to_s}", force_color: :green) unless self.respond_to?(action)
+
+        case arity = self.method(action).arity
+        when 0 then self.send(action) # Just call the method
+        when 2 then self.send(action, arguments, index_path) # Send arguments and index path
+        else
+          mp("Action should not have optional parameters: #{action.to_s}", force_color: :yellow) if arity < 0
+          self.send(action, arguments) # Send arguments
+        end
       end
     end
 

--- a/spec/unit/tables/table_module_spec.rb
+++ b/spec/unit/tables/table_module_spec.rb
@@ -41,6 +41,16 @@ describe "PM::Table module" do
     })
   end
 
+  def proc_cell
+    custom_cell.merge({
+      action: -> (args, index_path) {
+        args[:data].should == [ "lots", "of", "data" ]
+        index_path.section.should == 7
+        index_path.row.should == 0
+      }
+      })
+  end
+
   def default_cell_height
     return UITableViewAutomaticDimension if TestHelper.ios8
     return 97.0 if TestHelper.ios7 # Normally 44, but 97 because of `row_height` designation
@@ -70,19 +80,22 @@ describe "PM::Table module" do
         title: "Custom section title 2", title_view: CustomTitleView.new, title_view_height: 50, cells: [ ]
       },{
         title: "Action WIth Index Path Group", cells: [ cell_factory(title: "IndexPath Group 1", action: :tests_index_path) ]
-      }]
+      }, {
+        title: "Action With A Proc", cells: [ proc_cell ]
+        }]
     end
 
     @subject.on_load
 
     @ip = NSIndexPath.indexPathForRow(1, inSection: 2) # Cell 3-2
     @custom_ip = NSIndexPath.indexPathForRow(0, inSection: 3) # Cell "Crazy Full Featured Cell"
+    @proc_cell = NSIndexPath.indexPathForRow(0, inSection: 7)
 
     @subject.update_table_data
   end
 
   it "should have the right number of sections" do
-    @subject.numberOfSectionsInTableView(@subject.table_view).should == 7
+    @subject.numberOfSectionsInTableView(@subject.table_view).should == 8
   end
 
   it "should set the section titles" do
@@ -132,6 +145,10 @@ describe "PM::Table module" do
     end
 
     @subject.tableView(@subject.table_view, didSelectRowAtIndexPath:@custom_ip)
+  end
+
+  it "should trigger the proc" do
+    @subject.tableView(@subject.table_view, didSelectRowAtIndexPath: @proc_cell)
   end
 
   it "should return an NSIndexPath when the action has two parameters" do


### PR DESCRIPTION
Allow the use of a proc for :action in cells

```ruby
{
   action: -> (arguments, index_path) {
       mp arguments.inspect
   },
   arguments: {
      foo: :bar
   }
}
```