### PR TITLE
Use the trigger_action method to send the index_path when deleting a cell

### DIFF
--- a/app/screens/test_table_screen.rb
+++ b/app/screens/test_table_screen.rb
@@ -1,5 +1,5 @@
 class TestTableScreen < ProMotion::TableScreen
-  attr_accessor :tap_counter, :cell_was_deleted, :got_index_path, :cell_was_moved, :got_will_display_header
+  attr_accessor :tap_counter, :cell_was_deleted, :cell_deleted_index_path, :got_index_path, :cell_was_moved, :got_will_display_header
 
   title 'Test title'
   tab_bar_item title: 'Test tab title', item: 'test'
@@ -105,11 +105,12 @@ class TestTableScreen < ProMotion::TableScreen
     end
   end
 
-  def on_cell_deleted(cell)
+  def on_cell_deleted(cell, index_path)
     if cell[:title] == "A non-deletable blank row"
       false
     else
       self.cell_was_deleted = true
+      self.cell_deleted_index_path = index_path
     end
   end
 

--- a/docs/Reference/ProMotion TableScreen.md
+++ b/docs/Reference/ProMotion TableScreen.md
@@ -248,7 +248,7 @@ def will_display_cell(cell, index_path)
 end
 ```
 
-#### on_cell_deleted(cell)
+#### on_cell_deleted(cell, index_path)
 
 If you specify `editing_style: :delete` in your cell, you can swipe to reveal a delete button on that cell. When you tap the button, the cell will be removed in an animated fashion and the cell will be removed from its respective `table_data` section.
 
@@ -257,7 +257,7 @@ If you need a callback for every cell that's deleted, you can implement the `on_
 Example:
 
 ```ruby
-def on_cell_deleted(cell)
+def on_cell_deleted(cell, index_path)
   if cell[:arguments][:some_value] == "something"
     App.alert "Sorry, can't delete that row." # BubbleWrap alert
     false

--- a/lib/ProMotion/table/table.rb
+++ b/lib/ProMotion/table/table.rb
@@ -135,7 +135,8 @@ module ProMotion
       deletable_index_paths = []
       Array(index_paths).each do |index_path|
         delete_cell = false
-        delete_cell = send(:on_cell_deleted, cell_at(index_path: index_path)) if self.respond_to?("on_cell_deleted:")
+
+        delete_cell = trigger_action(:on_cell_deleted, cell_at(index_path: index_path), index_path) if respond_to?(:on_cell_deleted)
         unless delete_cell == false
           self.promotion_table_data.delete_cell(index_path: index_path)
           deletable_index_paths << index_path

--- a/spec/functional/func_table_screen_spec.rb
+++ b/spec/functional/func_table_screen_spec.rb
@@ -75,6 +75,7 @@ describe "ProMotion::TableScreen functionality" do
             wait 0.01 do
               table_screen.tableView(table_screen.tableView, numberOfRowsInSection:0).should == 6
               table_screen.cell_was_deleted.should == true
+              table_screen.cell_deleted_index_path.should == NSIndexPath.indexPathForRow(3, inSection:0)
             end
           end
         end


### PR DESCRIPTION
Still backwards compatible with a warning.

`323 specifications (659 requirements), 0 failures, 0 errors`

Updated docs too.